### PR TITLE
feat: create repository installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build/
 ### NPM ###
 node_modules/
 src/main/resources/static/felf.css
+src/main/resources/static/htmx.min.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.10",
         "daisyui": "^3.9.4",
+        "htmx.org": "^1.9.8",
         "tailwindcss": "^3.3.3"
       }
     },
@@ -433,6 +434,12 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/htmx.org": {
+      "version": "1.9.8",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.8.tgz",
+      "integrity": "sha512-eH825QM6yJ1AeHTJgUxy3xnXnP/uXD56x52/VYnQ9CMw+o9H04ar/GY5PHuiZeelsqLK4wkviVdCel7u+3h4Fw==",
+      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
+  "scripts": {
+    "htmx": "cp node_modules/htmx.org/dist/htmx.min.js src/main/resources/static",
+    "css": "tailwindcss -i src/main/resources/static/input.css -o src/main/resources/static/felf.css",
+    "csswatch": "npm run css -- --watch",
+    "build": "npm run htmx && npm run tailwind"
+  },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",
     "daisyui": "^3.9.4",
+    "htmx.org": "^1.9.8",
     "tailwindcss": "^3.3.3"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -170,13 +170,10 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <executable>npx</executable>
+                    <executable>npm</executable>
                     <arguments>
-                        <argument>tailwindcss</argument>
-                        <argument>-i</argument>
-                        <argument>./src/main/resources/static/input.css</argument>
-                        <argument>-o</argument>
-                        <argument>./src/main/resources/static/felf.css</argument>
+                        <argument>run</argument>
+                        <argument>build</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/src/main/java/com/zoftko/felf/controllers/AppController.java
+++ b/src/main/java/com/zoftko/felf/controllers/AppController.java
@@ -1,13 +1,21 @@
 package com.zoftko.felf.controllers;
 
 import com.zoftko.felf.entities.Installation;
+import com.zoftko.felf.models.InstallationRepos;
 import com.zoftko.felf.services.GithubService;
 import java.security.Principal;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.server.ResponseStatusException;
 
 @Controller
 public class AppController {
@@ -24,10 +32,49 @@ public class AppController {
         List<Installation> installations = githubService.getUserInstallations(
             Integer.parseInt(principal.getName())
         );
-
         model.addAttribute("installations", installations);
         model.addAttribute("defaultInstallation", installations.isEmpty() ? null : installations.getFirst());
 
         return "dashboard";
+    }
+
+    @GetMapping("/fragments/{installationId}/projects")
+    public String getProjects(
+        @PathVariable Integer installationId,
+        @AuthenticationPrincipal OAuth2User principal,
+        Model model
+    ) {
+        if (
+            githubService.userForbiddenFromInstallation(Integer.parseInt(principal.getName()), installationId)
+        ) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+        model.addAttribute("projects", githubService.getInstallationProjects(installationId));
+        model.addAttribute("installationId", installationId);
+
+        return "fragments/projectTable";
+    }
+
+    @GetMapping("/fragments/{installationId}/repos")
+    public String getRepos(
+        @PathVariable Integer installationId,
+        @AuthenticationPrincipal OAuth2User principal,
+        @RequestParam(defaultValue = "" + GithubService.DEFAULT_PAGE) int page,
+        @RequestParam(defaultValue = "" + GithubService.DEFAULT_PAGE_SIZE) int size,
+        Model model
+    ) {
+        if (
+            githubService.userForbiddenFromInstallation(Integer.parseInt(principal.getName()), installationId)
+        ) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+
+        var response = Optional.ofNullable(
+            githubService.getInstallationRepositories(installationId, page, size).block()
+        );
+        model.addAttribute("totalCount", response.map(InstallationRepos::totalCount).orElse(0));
+        model.addAttribute("repos", response.map(InstallationRepos::repositories).orElse(null));
+
+        return "addRepoModal";
     }
 }

--- a/src/main/java/com/zoftko/felf/dao/InstallationRepository.java
+++ b/src/main/java/com/zoftko/felf/dao/InstallationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InstallationRepository extends JpaRepository<Installation, Integer> {
     List<Installation> findBySender(Integer sender);
+    Installation findBySenderAndId(Integer sender, Integer id);
 }

--- a/src/main/java/com/zoftko/felf/dao/ProjectRepository.java
+++ b/src/main/java/com/zoftko/felf/dao/ProjectRepository.java
@@ -1,0 +1,9 @@
+package com.zoftko.felf.dao;
+
+import com.zoftko.felf.entities.Project;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Integer> {
+    List<Project> findByInstallationId(Integer installationId);
+}

--- a/src/main/java/com/zoftko/felf/entities/Project.java
+++ b/src/main/java/com/zoftko/felf/entities/Project.java
@@ -1,0 +1,54 @@
+package com.zoftko.felf.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Entity
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @NotNull
+    private Integer repository;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Installation installation;
+
+    @NotBlank
+    private String fullName;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getRepository() {
+        return repository;
+    }
+
+    public void setRepository(Integer repositoryId) {
+        this.repository = repositoryId;
+    }
+
+    public Installation getInstallation() {
+        return installation;
+    }
+
+    public void setInstallation(Installation installationId) {
+        this.installation = installationId;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName.trim();
+    }
+}

--- a/src/main/java/com/zoftko/felf/models/InstallationRepos.java
+++ b/src/main/java/com/zoftko/felf/models/InstallationRepos.java
@@ -1,0 +1,12 @@
+package com.zoftko.felf.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * Response returned by /installation/repositories
+ */
+public record InstallationRepos(@JsonProperty("total_count") Integer totalCount, List<Repo> repositories) {
+    public record Repo(Integer id, String name, Boolean isPrivate, URL htmlUrl) {}
+}

--- a/src/main/java/com/zoftko/felf/services/GithubService.java
+++ b/src/main/java/com/zoftko/felf/services/GithubService.java
@@ -1,10 +1,16 @@
 package com.zoftko.felf.services;
 
 import com.zoftko.felf.dao.InstallationRepository;
+import com.zoftko.felf.dao.ProjectRepository;
 import com.zoftko.felf.entities.Installation;
+import com.zoftko.felf.entities.Project;
+import com.zoftko.felf.models.InstallationRepos;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Service
 public class GithubService {
@@ -12,15 +18,49 @@ public class GithubService {
     public static final String HTTP_HEADER_GH_UID = "X-Github-Uid";
     public static final String QUALIFIER_INSTALL_TOKEN = "gh-install";
     public static final String QUALIFIER_APP_TOKEN = "gh-app";
+    public static final int DEFAULT_PAGE = 1;
+    public static final int DEFAULT_PAGE_SIZE = 30;
 
     private final InstallationRepository installationRepository;
+    private final ProjectRepository projectRepository;
+    private final WebClient client;
 
     @Autowired
-    public GithubService(InstallationRepository installationRepository) {
+    public GithubService(
+        InstallationRepository installationRepository,
+        ProjectRepository projectRepository,
+        @Qualifier(QUALIFIER_INSTALL_TOKEN) WebClient client
+    ) {
+        this.client = client;
+        this.projectRepository = projectRepository;
         this.installationRepository = installationRepository;
     }
 
-    public List<Installation> getUserInstallations(Integer id) {
+    public List<Installation> getUserInstallations(int id) {
         return installationRepository.findBySender(id);
+    }
+
+    public boolean userForbiddenFromInstallation(int userId, int installationId) {
+        return installationRepository.findBySenderAndId(userId, installationId) == null;
+    }
+
+    public List<Project> getInstallationProjects(int installationId) {
+        return projectRepository.findByInstallationId(installationId);
+    }
+
+    public Mono<InstallationRepos> getInstallationRepositories(int installation, int page, int perPage) {
+        return client
+            .get()
+            .uri(builder ->
+                builder
+                    .path("/installation/repositories")
+                    .queryParam("page", page)
+                    .queryParam("per_page", perPage)
+                    .build()
+            )
+            .header(HTTP_HEADER_GH_UID, Integer.toString(installation))
+            .retrieve()
+            .bodyToMono(InstallationRepos.class)
+            .cache();
     }
 }

--- a/src/main/resources/db/changelog/changes/2-create-project.yaml
+++ b/src/main/resources/db/changelog/changes/2-create-project.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2-create-projects
+      author: anton
+      changes:
+        - createTable:
+            tableName: project
+            columns:
+              - column:
+                  name: id
+                  type: serial
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: repository
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: installation_id
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: full_name
+                  type: varchar(256)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: project
+            columnNames: repository,installation_id

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" layout:decorate="~{layouts/full}">
   <body>
-    <main layout:fragment="content" class="mx-auto grow p-4 flex place-items-center container">
+    <main layout:fragment="content" class="mx-auto grow p-4 flex flex-col container">
       <div th:if="${installations.isEmpty()}" class="flex flex-col gap-4 items-center m-auto">
         <h1 class="text-4xl">Welcome!</h1>
         <h2 class="text-2xl">To get started, please install the application</h2>
@@ -10,7 +10,7 @@
         >
       </div>
       <th:block th:if="${installations.size()}">
-        <div class="flex flex-col mb-auto">
+        <div class="flex flex-col">
           <div class="flex flex-col items-start">
             <label for="projectSelect" class="label text-xl font-bold mr-2">Accounts</label>
             <a class="link text-sm opacity-70" href="https://github.com/apps/elf-watch/installations/new"
@@ -40,6 +40,11 @@
             </select>
           </div>
         </div>
+        <div
+          class="mx-auto mt-10"
+          th:hx-get="@{/fragments/{id}/projects(id=${defaultInstallation.getId()})}"
+          hx-trigger="load"
+        ></div>
       </th:block>
     </main>
   </body>

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -4,5 +4,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" th:href="@{/static/felf.css}" />
     <link rel="icon" type="image/x-icon" th:href="@{/static/felf.ico}" />
+    <script th:src="@{/static/htmx.min.js}"></script>
   </th:block>
 </head>

--- a/src/main/resources/templates/fragments/projectTable.html
+++ b/src/main/resources/templates/fragments/projectTable.html
@@ -1,0 +1,31 @@
+<table th:if="${!projects.isEmpty()}">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Flash</th>
+      <th>RAM</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr th:each="project : ${projects}">
+      <td th:text="${project.getFullName()}"></td>
+      <td>Unknown</td>
+      <td>Unknown</td>
+    </tr>
+  </tbody>
+</table>
+<th:block th:if="${projects.isEmpty()}">
+  <div class="flex flex-col items-center">
+    <h2 class="text-2xl">No projects have been set up</h2>
+    <h2 class="text-2xl">Add one to get started</h2>
+    <button class="btn btn-primary mt-4" id="show_modal_btn" onclick="add_repos_modal.showModal()">
+      Add
+    </button>
+  </div>
+  <dialog class="modal" id="add_repos_modal">
+    <form method="dialog">
+      <button class="btn">X</button>
+    </form>
+    <div th:hx-get="@{/fragments/{id}/repos(id=${installationId})}" hx-trigger="from:#show_modal_btn"></div>
+  </dialog>
+</th:block>

--- a/src/main/resources/templates/fragments/repoList.html
+++ b/src/main/resources/templates/fragments/repoList.html
@@ -1,0 +1,3 @@
+<ul>
+  <li th:each="repo : ${repos}" th:text="${repo.name()}"></li>
+</ul>


### PR DESCRIPTION
The option to create projects (repository installations) has been
added. Projects contain all the measurements for a given repository
and the access tokens linked to it.

Projects are linked to an account installation, when no projects exist,
the user is prompted to add one. The addition process displays a modal
with all the repositories that have no linked projects, upon clicking a
new project is created and the user redirected to it.