### PR TITLE
feat: upsert analysis for merge requests

### DIFF
--- a/src/main/java/com/zoftko/felf/controllers/AnalysisController.java
+++ b/src/main/java/com/zoftko/felf/controllers/AnalysisController.java
@@ -56,6 +56,11 @@ public class AnalysisController {
 
         analysis.setProject(project.get());
         analysis.setCreatedAt(LocalDateTime.now());
+
+        if (analysis.getRef().endsWith("/merge")) {
+            var existing = analysisRepository.findByProjectAndRef(analysis.getProject(), analysis.getRef());
+            existing.ifPresent(value -> analysis.setId(value.getId()));
+        }
         analysisRepository.save(analysis);
 
         return ResponseEntity.ok().build();

--- a/src/main/java/com/zoftko/felf/dao/AnalysisRepository.java
+++ b/src/main/java/com/zoftko/felf/dao/AnalysisRepository.java
@@ -9,4 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
     @Query("SELECT m FROM Analysis m WHERE m.project = ?1 AND m.ref = ?2 ORDER BY m.createdAt DESC")
     Optional<Analysis> getLastAnalysisByRef(Project project, String ref);
+
+    Optional<Analysis> findByProjectAndRef(Project project, String ref);
 }


### PR DESCRIPTION
Historical data is to only be shown on branches, therefore analysis records for merge requests (those where the ref ends in /merge) will be updated instead of created per push.

Closes #12.