### PR TITLE
fix: prevent form submission when copying token

### DIFF
--- a/src/main/resources/templates/pages/repository/token.html
+++ b/src/main/resources/templates/pages/repository/token.html
@@ -14,7 +14,7 @@
         id="token"
         disabled
       />
-      <button class="btn join-item" onclick="clipboardCopy()">Copy</button>
+      <button type="button" class="btn join-item" onclick="clipboardCopy()">Copy</button>
     </div>
     <div class="label">
       <span


### PR DESCRIPTION
After generating a token and clicking on the copy button to copy it to the clipboard, the form would be resubmitted and a new token generated. The button type was specified to prevent this.

Closes #10.