### PR TITLE
Obtain repository default branch and visibility

### DIFF
--- a/src/main/java/com/zoftko/felf/controllers/RepositoryController.java
+++ b/src/main/java/com/zoftko/felf/controllers/RepositoryController.java
@@ -61,6 +61,10 @@ public class RepositoryController {
         model.addAttribute("isOwner", projectData.isOwner(Integer.parseInt(principal.getName())));
         model.addAttribute("hasPermissions", projectData.hasPermissions());
         model.addAttribute("fullName", projectData.fullName());
+        model.addAttribute(
+            "isPrivate",
+            projectData.repository() != null && projectData.repository().isPrivate()
+        );
 
         projectData
             .project()
@@ -103,6 +107,9 @@ public class RepositoryController {
         var projectData = felfService.getFreshProjectData(owner, repo);
         if (!projectData.isOwner(Integer.parseInt(principal.getName()))) {
             throw new ResponseStatusException(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+        }
+        if (projectData.repository() == null || projectData.repository().isPrivate()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
 
         var project = projectData.project().orElse(projectData.initializeProject());

--- a/src/main/java/com/zoftko/felf/dao/ProjectRepository.java
+++ b/src/main/java/com/zoftko/felf/dao/ProjectRepository.java
@@ -3,8 +3,19 @@ package com.zoftko.felf.dao;
 import com.zoftko.felf.entities.Project;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProjectRepository extends JpaRepository<Project, Integer> {
     Optional<Project> findByFullName(String fullName);
     Optional<Project> findByToken(String token);
+
+    @Modifying
+    @Query("UPDATE Project p SET p.defaultBranch = :branch WHERE p.fullName = :name")
+    void updateDefaultBranchByFullName(@Param("name") String fullName, @Param("branch") String branch);
+
+    @Modifying
+    @Query("UPDATE Project p SET p.isPrivate = :private WHERE p.fullName = :name")
+    void updateIsPrivateByFullName(@Param("name") String fullName, @Param("private") boolean isPrivate);
 }

--- a/src/main/java/com/zoftko/felf/entities/Project.java
+++ b/src/main/java/com/zoftko/felf/entities/Project.java
@@ -24,6 +24,9 @@ public class Project {
     @NotBlank
     private String token;
 
+    @Column(name = "private")
+    private boolean isPrivate;
+
     public Integer getId() {
         return id;
     }
@@ -79,5 +82,13 @@ public class Project {
         setToken(encoder.encode(newToken));
 
         return newToken;
+    }
+
+    public boolean getPrivate() {
+        return isPrivate;
+    }
+
+    public void setPrivate(boolean aPrivate) {
+        isPrivate = aPrivate;
     }
 }

--- a/src/main/java/com/zoftko/felf/models/ProjectData.java
+++ b/src/main/java/com/zoftko/felf/models/ProjectData.java
@@ -8,7 +8,8 @@ public record ProjectData(
     String fullName,
     Optional<Project> project,
     Optional<Installation> installation,
-    RepositoryInstallation repoInstall
+    RepositoryInstallation repoInstall,
+    Repository repository
 ) {
     public boolean isOwner(int userId) {
         if (repoInstall == null) {
@@ -32,13 +33,15 @@ public record ProjectData(
     }
 
     public Project initializeProject() throws IllegalStateException {
-        if (installation.isEmpty() || repoInstall == null) {
+        if (installation.isEmpty() || repoInstall == null || repository == null) {
             throw new IllegalStateException();
         }
 
         var initProject = new Project();
         initProject.setFullName(fullName());
+        initProject.setPrivate(repository.isPrivate());
         initProject.setInstallation(installation.get());
+        initProject.setDefaultBranch(repository.defaultBranch());
 
         return initProject;
     }

--- a/src/main/java/com/zoftko/felf/models/Repository.java
+++ b/src/main/java/com/zoftko/felf/models/Repository.java
@@ -1,0 +1,8 @@
+package com.zoftko.felf.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record Repository(String fullName, @JsonProperty("private") boolean isPrivate, String defaultBranch) {}

--- a/src/main/java/com/zoftko/felf/services/FelfService.java
+++ b/src/main/java/com/zoftko/felf/services/FelfService.java
@@ -4,6 +4,7 @@ import com.zoftko.felf.dao.InstallationRepository;
 import com.zoftko.felf.dao.ProjectRepository;
 import com.zoftko.felf.entities.Project;
 import com.zoftko.felf.models.ProjectData;
+import com.zoftko.felf.models.Repository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
@@ -40,7 +41,16 @@ public class FelfService {
             .onErrorResume(__ -> Mono.empty())
             .block();
 
-        return new ProjectData(fullName, project, installation, repoInstall);
+        Repository repository = null;
+        if (repoInstall != null) {
+            repository =
+                githubService
+                    .getRepository(repoInstall.id(), owner, repo)
+                    .onErrorResume(__ -> Mono.empty())
+                    .block();
+        }
+
+        return new ProjectData(fullName, project, installation, repoInstall, repository);
     }
 
     @CacheEvict(key = "#project.fullName")

--- a/src/main/java/com/zoftko/felf/services/GithubService.java
+++ b/src/main/java/com/zoftko/felf/services/GithubService.java
@@ -1,5 +1,6 @@
 package com.zoftko.felf.services;
 
+import com.zoftko.felf.models.Repository;
 import com.zoftko.felf.models.RepositoryInstallation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -15,10 +16,15 @@ public class GithubService {
     public static final String QUALIFIER_APP_TOKEN = "gh-app";
 
     private final WebClient appClient;
+    private final WebClient installClient;
 
     @Autowired
-    public GithubService(@Qualifier(QUALIFIER_APP_TOKEN) WebClient appClient) {
+    public GithubService(
+        @Qualifier(QUALIFIER_APP_TOKEN) WebClient appClient,
+        @Qualifier(QUALIFIER_INSTALL_TOKEN) WebClient installClient
+    ) {
         this.appClient = appClient;
+        this.installClient = installClient;
     }
 
     public Mono<RepositoryInstallation> getRepositoryInstallation(String owner, String repo) {
@@ -27,5 +33,14 @@ public class GithubService {
             .uri(builder -> builder.pathSegment("repos", owner, repo, "installation").build())
             .retrieve()
             .bodyToMono(RepositoryInstallation.class);
+    }
+
+    public Mono<Repository> getRepository(int installationId, String owner, String repo) {
+        return installClient
+            .get()
+            .uri(builder -> builder.pathSegment("repos", owner, repo).build())
+            .header(HTTP_HEADER_GH_UID, Integer.toString(installationId))
+            .retrieve()
+            .bodyToMono(Repository.class);
     }
 }

--- a/src/main/java/com/zoftko/felf/services/WebhookService.java
+++ b/src/main/java/com/zoftko/felf/services/WebhookService.java
@@ -2,6 +2,7 @@ package com.zoftko.felf.services;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.zoftko.felf.dao.InstallationRepository;
+import com.zoftko.felf.dao.ProjectRepository;
 import com.zoftko.felf.entities.Installation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,16 +14,26 @@ import org.springframework.stereotype.Service;
 public class WebhookService {
 
     public static final String EVENT_INSTALLATION = "installation";
+    public static final String EVENT_REPOSITORY = "repository";
+
     public static final String ACTION_DELETED = "deleted";
     public static final String ACTION_CREATED = "created";
+    public static final String ACTION_EDITED = "edited";
+    public static final String ACTION_PRIVATIZED = "privatized";
+    public static final String ACTION_PUBLICIZED = "publicized";
 
     private final InstallationRepository installationRepository;
+    private final ProjectRepository projectRepository;
 
     private final Logger log = LoggerFactory.getLogger(WebhookService.class);
 
     @Autowired
-    public WebhookService(InstallationRepository installationRepository) {
+    public WebhookService(
+        InstallationRepository installationRepository,
+        ProjectRepository projectRepository
+    ) {
         this.installationRepository = installationRepository;
+        this.projectRepository = projectRepository;
     }
 
     private Installation jsonToInstallation(JsonNode json) {
@@ -55,10 +66,29 @@ public class WebhookService {
         }
     }
 
+    private void processRepositoryEvent(JsonNode payload) {
+        String action = payload.path("action").asText("none");
+        String fullName = payload.path(EVENT_REPOSITORY).path("full_name").asText();
+
+        log.info("processing repository action '{}'", action);
+        switch (action) {
+            case ACTION_EDITED -> {
+                String defaultBranch = payload.path(EVENT_REPOSITORY).path("default_branch").asText("");
+                projectRepository.updateDefaultBranchByFullName(fullName, defaultBranch);
+            }
+            case ACTION_PRIVATIZED -> projectRepository.updateIsPrivateByFullName(fullName, true);
+            case ACTION_PUBLICIZED -> projectRepository.updateIsPrivateByFullName(fullName, false);
+            default -> log.info("repository action {} is not supported", action);
+        }
+    }
+
     @Async
     public void processEvent(String event, JsonNode payload) {
-        if (event.equals(EVENT_INSTALLATION)) {
-            processInstallationEvent(payload);
+        log.info("processing {} event", event);
+        switch (event) {
+            case EVENT_INSTALLATION -> processInstallationEvent(payload);
+            case EVENT_REPOSITORY -> processRepositoryEvent(payload);
+            default -> log.info("{} is not supported", event);
         }
     }
 }

--- a/src/main/resources/db/changelog/changes/7-add-col-project-private.yaml
+++ b/src/main/resources/db/changelog/changes/7-add-col-project-private.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 7-add-col-project-private.yaml
+      author: anton
+      changes:
+        - addColumn:
+            tableName: project
+            columns:
+              - column:
+                  name: private
+                  type: bool
+                  defaultValueBoolean: false

--- a/src/main/resources/templates/pages/repository/index.html
+++ b/src/main/resources/templates/pages/repository/index.html
@@ -5,11 +5,18 @@
   </head>
   <body>
     <main layout:fragment="content" class="mx-auto grow p-4 flex flex-col container">
-      <div class="text-center" th:unless="${projectPresent or isOwner}">
+      <div class="text-center" th:unless="${(projectPresent or isOwner) and !isPrivate}">
         <h1 class="text-2xl md:text-6xl font-bold mt-8">Not found</h1>
         <div class="mt-6">
           <p class="text-4xl md:text-6xl mb-4">🧐</p>
-          <p class="text-xl md:text-2xl">This repository does not exist or has not been configured.</p>
+          <p class="text-xl md:text-2xl">
+            This repository is
+            <span
+              class="tooltip underline decoration-dotted"
+              data-tip="Private repositories are not supported at the moment"
+              >private</span
+            >, does not exist or has not been configured.
+          </p>
           <p class="text-xl md:text-2xl mt-4">
             If you are the owner of this repository
             <a class="underline" href="https://github.com/apps/elf-watch/installations/new"
@@ -19,7 +26,7 @@
           </p>
         </div>
       </div>
-      <div th:if="${projectPresent or isOwner}">
+      <div th:if="${(projectPresent or isOwner) and !isPrivate}">
         <div class="flex items-center mt-6">
           <div class="mb-8 pr-8 pb-6 border-b-neutral-content border-b-2 flex">
             <h1 class="font-bold text-2xl md:text-3xl inline-block" th:text="${fullName}"></h1>

--- a/src/test/java/com/zoftko/felf/controllers/RepositoryControllerTests.java
+++ b/src/test/java/com/zoftko/felf/controllers/RepositoryControllerTests.java
@@ -12,6 +12,7 @@ import com.zoftko.felf.entities.Installation;
 import com.zoftko.felf.entities.Project;
 import com.zoftko.felf.entities.Size;
 import com.zoftko.felf.models.ProjectData;
+import com.zoftko.felf.models.Repository;
 import com.zoftko.felf.models.RepositoryInstallation;
 import com.zoftko.felf.services.FelfService;
 import java.util.Map;
@@ -45,6 +46,7 @@ class RepositoryControllerTests extends BaseControllerTest {
     static Project project;
     static Installation installation;
     static RepositoryInstallation repoInstall;
+    static Repository repository;
 
     @BeforeAll
     static void setupAll() {
@@ -56,12 +58,15 @@ class RepositoryControllerTests extends BaseControllerTest {
         project.setDefaultBranch("main");
 
         repoInstall = new RepositoryInstallation(installId, Map.of("pull_request", "write"), null);
+        repository = new Repository(fullName, false, "main");
     }
 
     @Test
     void noProjectNoRepo() throws Exception {
         when(felfService.getProjectData(owner, repo))
-            .thenReturn(new ProjectData(fullName, Optional.empty(), Optional.of(new Installation()), null));
+            .thenReturn(
+                new ProjectData(fullName, Optional.empty(), Optional.of(new Installation()), null, null)
+            );
 
         assertThat(
             mockMvc.perform(get(getTestUrl).with(githubLogin(123))).andReturn().getModelAndView().getModel()
@@ -75,7 +80,13 @@ class RepositoryControllerTests extends BaseControllerTest {
     void projectNoAnalysis() throws Exception {
         when(felfService.getProjectData(owner, repo))
             .thenReturn(
-                new ProjectData(fullName, Optional.of(project), Optional.of(installation), repoInstall)
+                new ProjectData(
+                    fullName,
+                    Optional.of(project),
+                    Optional.of(installation),
+                    repoInstall,
+                    repository
+                )
             );
         when(analysisRepository.getLastAnalysisByRef(project, "main")).thenReturn(Optional.empty());
 
@@ -101,7 +112,13 @@ class RepositoryControllerTests extends BaseControllerTest {
     void projectWithAnalysis() throws Exception {
         when(felfService.getProjectData(owner, repo))
             .thenReturn(
-                new ProjectData(fullName, Optional.of(project), Optional.of(installation), repoInstall)
+                new ProjectData(
+                    fullName,
+                    Optional.of(project),
+                    Optional.of(installation),
+                    repoInstall,
+                    repository
+                )
             );
 
         var analysis = new Analysis();
@@ -120,7 +137,15 @@ class RepositoryControllerTests extends BaseControllerTest {
     @Test
     void createRepositoryTokenNoProject() throws Exception {
         when(felfService.getFreshProjectData(owner, repo))
-            .thenReturn(new ProjectData(fullName, Optional.empty(), Optional.of(installation), repoInstall));
+            .thenReturn(
+                new ProjectData(
+                    fullName,
+                    Optional.empty(),
+                    Optional.of(installation),
+                    repoInstall,
+                    repository
+                )
+            );
 
         assertThat(
             mockMvc

--- a/src/test/java/com/zoftko/felf/services/FelfServiceTests.java
+++ b/src/test/java/com/zoftko/felf/services/FelfServiceTests.java
@@ -9,6 +9,7 @@ import com.zoftko.felf.dao.InstallationRepository;
 import com.zoftko.felf.dao.ProjectRepository;
 import com.zoftko.felf.entities.Installation;
 import com.zoftko.felf.entities.Project;
+import com.zoftko.felf.models.Repository;
 import com.zoftko.felf.models.RepositoryInstallation;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +44,8 @@ class FelfServiceTests {
 
         when(githubService.getRepositoryInstallation(anyString(), anyString()))
             .thenReturn(Mono.just(new RepositoryInstallation(123, Map.of(), null)));
+        when(githubService.getRepository(anyInt(), anyString(), anyString()))
+            .thenReturn(Mono.just(new Repository(name, false, "main")));
         when(installationRepository.findByAccountLogin(anyString()))
             .thenReturn(Optional.of(new Installation()));
         when(projectRepository.findByFullName(anyString())).thenReturn(Optional.of(new Project()));

--- a/src/test/java/com/zoftko/felf/services/GithubServiceTests.java
+++ b/src/test/java/com/zoftko/felf/services/GithubServiceTests.java
@@ -18,7 +18,7 @@ class GithubServiceTests {
     @BeforeEach
     void setUp() {
         client = WebClient.builder().baseUrl(server.url("/").toString()).build();
-        service = new GithubService(client);
+        service = new GithubService(client, client);
     }
 
     @Test
@@ -29,6 +29,17 @@ class GithubServiceTests {
         var request = server.takeRequest();
         assertThat(request.getRequestUrl().encodedPath())
             .isEqualTo("/repos/crazybolillo/dotconfig/installation");
+        assertThat(request.getMethod()).isEqualToIgnoringCase("GET");
+    }
+
+    @Test
+    void getRepository() throws InterruptedException {
+        server.enqueue(new MockResponse());
+        service.getRepository(12345, "zoftko", "felf").block();
+
+        var request = server.takeRequest();
+        assertThat(request.getRequestUrl().encodedPath()).isEqualTo("/repos/zoftko/felf");
+        assertThat(request.getHeader(GithubService.HTTP_HEADER_GH_UID)).isEqualTo("12345");
         assertThat(request.getMethod()).isEqualToIgnoringCase("GET");
     }
 }


### PR DESCRIPTION
Repositories' default branch and visibility are now stored and kept up to date with the help of webhooks. For the moment it was chosen to disable support for private repositories.

Closes #8 .