### PR TITLE
feat: support installation_repositories webhook

### DIFF
--- a/src/main/java/com/zoftko/felf/services/FelfService.java
+++ b/src/main/java/com/zoftko/felf/services/FelfService.java
@@ -14,8 +14,10 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
-@CacheConfig(cacheNames = "felf-service")
+@CacheConfig(cacheNames = FelfService.CACHE_NAME)
 public class FelfService {
+
+    public static final String CACHE_NAME = "felf-service";
 
     private final InstallationRepository installationRepository;
     private final ProjectRepository projectRepository;


### PR DESCRIPTION
Cache entries are evicted when repositories are added, this is automatically done by processing installation_repositories events.

Closes #15.