### PR TITLE
feat: hide exception details on error page

### DIFF
--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -2,13 +2,26 @@
 <html lang="en" layout:decorate="~{layouts/full}">
   <body>
     <main layout:fragment="content" class="container mx-auto flex grow items-center justify-center">
-      <div class="text-center">
-        <p class="text-2xl font-semibold" th:text="${status} ?: _">Oops</p>
-        <h1 class="mt-4 text-3xl font-bold tracking-tight sm:text-5xl" th:if="${error}" th:text="${error}">
-          Error Message
-        </h1>
-        <p class="mt-6 text-base leading-7" th:text="${message} ?: _">Sorry, we are having trouble.</p>
-        <div class="mt-10 flex items-center justify-center gap-x-6">
+      <div class="text-center" th:if="${status != 404}">
+        <h3 class="text-4xl md:text-6xl mb-2">Oops!</h3>
+        <p class="text-2xl md:text-4xl">
+          Something went wrong.
+          <br />
+          If this problem persists please report it.
+        </p>
+        <div class="mt-6 flex items-center justify-center gap-x-6">
+          <a th:href="@{/}" class="btn btn-accent">Go back home</a>
+        </div>
+      </div>
+      <div class="text-center" th:if="${status == 404}">
+        <h3 class="text-4xl md:text-6xl mb-2">Not Found</h3>
+        <p class="text-2xl md:text-4xl">
+          The page you are trying to access
+          <br />
+          does not exist.
+        </p>
+
+        <div class="mt-6 flex items-center justify-center gap-x-6">
           <a th:href="@{/}" class="btn btn-accent">Go back home</a>
         </div>
       </div>


### PR DESCRIPTION
The error page now shows a generic message instead of displaying a stack trace or exception message.

Closes #2.