### PR TITLE
ref: use base64 encoded pem file contents

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -67,7 +67,7 @@ jobs:
           echo 'spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver' >> config/application.properties
           echo "spring.security.oauth2.client.registration.github.client-id=dummy" >> config/application.properties
           echo "spring.security.oauth2.client.registration.github.client-secret=dummy" >> config/application.properties
-          echo "felf.github.app.pem=$(readlink -m config/felf.pem)" >> config/application.properties
+          echo "felf.github.app.pem=$(base64 config/felf.pem | xargs | sed 's/ //g')" >> config/application.properties
           echo "felf.github.app.id=$((RANDOM + 100000))" >> config/application.properties
           echo "felf.github.app.webhook.secret=watup" >> config/application.properties
           cat config/application.properties


### PR DESCRIPTION
The PEM file used to sign JSON Web Tokens was being previously read from a file on disk, this makes it harder to use modern cloud deployment technologies.

Therefore instead of reading from a file, the PEM is now provided through a base64 encoded representation of it, this makes it possible to pass it to the server as an environment variable.