### PR TITLE
ci: fix build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "htmx": "cp node_modules/htmx.org/dist/htmx.min.js src/main/resources/static/lib",
     "css": "tailwindcss -i src/main/resources/static/css/input.css -o src/main/resources/static/css/felf.css",
     "csswatch": "npm run css -- --watch",
-    "build": "npm run htmx && npm run tailwind"
+    "build": "npm run htmx && npm run css"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.10",

--- a/pom.xml
+++ b/pom.xml
@@ -170,16 +170,33 @@
                 <version>3.1.0</version>
                 <executions>
                     <execution>
+                        <id>npm-install</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
                         <phase>generate-resources</phase>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>install</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-build</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>build</argument>
+                            </arguments>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <executable>npm</executable>
-                    <arguments>
-                        <argument>run</argument>
-                        <argument>build</argument>
-                    </arguments>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
Apparently it had never worked properly. Now npm dependencies are installed and JS/CSS resources included in the build.